### PR TITLE
Convert backslash to forward slash

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ module.exports = ({ files, markdownAST, markdownNode, getNode, pathPrefix }) => 
       }
 
       const name = `${imageNode.name}-${imageNode.internal.contentDigest}.${imageNode.extension}`;
-      node.url = path.join(pathPrefix || '/', 'static', name);
+      node.url = path.join(pathPrefix || '/', 'static', name).replace(/\\/g, '/');
 
       const imageFile = path.join(process.cwd(), 'public/static', name);
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
On windows the path is incorrectly evaluated (\static\some_image.jpg) because it uses backslash separator in path.join and in browser it referenced as from current page not from root.